### PR TITLE
GDExtension: Copy DLL to a temp file before opening

### DIFF
--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -43,6 +43,9 @@ class GDExtension : public Resource {
 
 	void *library = nullptr; // pointer if valid,
 	String library_path;
+#if defined(WINDOWS_ENABLED) && defined(TOOLS_ENABLED)
+	String temp_lib_path;
+#endif
 
 	struct Extension {
 		ObjectGDExtension gdextension;
@@ -75,6 +78,10 @@ public:
 
 	Error open_library(const String &p_path, const String &p_entry_symbol);
 	void close_library();
+
+#if defined(WINDOWS_ENABLED) && defined(TOOLS_ENABLED)
+	void set_temp_library_path(const String &p_path) { temp_lib_path = p_path; }
+#endif
 
 	enum InitializationLevel {
 		INITIALIZATION_LEVEL_CORE = GDEXTENSION_INITIALIZATION_CORE,

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1522,6 +1522,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		}
 	}
 
+#ifdef TOOLS_ENABLED
+	if (editor) {
+		Engine::get_singleton()->set_editor_hint(true);
+	}
+#endif
+
 	// Initialize user data dir.
 	OS::get_singleton()->ensure_user_data_dir();
 
@@ -1549,7 +1555,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 	if (editor) {
 		packed_data->set_disabled(true);
-		Engine::get_singleton()->set_editor_hint(true);
 		main_args.push_back("--editor");
 		if (!init_windowed) {
 			init_maximized = true;


### PR DESCRIPTION
This is done only in the editor and only on Windows, to avoid a file lock that prevents the original library being updated (e.g. by a compiler).

When the game runs it will load the original DLL and pick up any changes, only the editor will stay with the copy (until it is restarted and create a new copy).

The copy is done in place by prepending a `~` to the original file name, so dependencies that are loaded with a relative file path still work. When the library is unloaded the copy file is deleted.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
